### PR TITLE
wrap in container. add section for markdown editor

### DIFF
--- a/MarkdownEditor.elm
+++ b/MarkdownEditor.elm
@@ -14,22 +14,53 @@ import Html.Attributes exposing (id, type', for, value, class, style)
 view =
     div
     [
-        navStyle
-    ][
+        containerStyle
+    ] [
+        div
+        [
+            navStyle
+        ][
+        ],
+        div
+        [
+            markdownStyle
+        ] [
+
+        ]
+    ]
+containerStyle: Attribute
+containerStyle =
+    style
+    [   ("position", "absolute")
+    ,   ("display", "flex")
+    ,   ("flex-direction", "column")
+    ,   ("flex-wrap", "no-wrap")
+    ,   ("align-items", "center")
+    ,   ("top", "0")
+    ,   ("bottom", "0")
+    ,   ("left", "0")
+    ,   ("right", "0")
+    ,   ("background-color", "#303030")
     ]
 
 navStyle: Attribute
 navStyle =
     style
-    [   ("position", "absolute")
-    ,   ("width", "100%")
+    [   ("width", "100%")
     ,   ("height", "55px")
     ,   ("display", "flex")
     ,   ("flex-direction", "row")
-    ,   ("background-color", "#1abc9c")
-    ,   ("top", "0")
-    ,   ("left", "0")
-    ,   ("box-shadow", "0px 2px 2px #34495e")
+    ,   ("background-color", "#212121")
+    ,   ("box-shadow", "0px 2px 2px #000000")
     ]
 
+markdownStyle: Attribute
+markdownStyle =
+    style
+    [   ("width", "75%")
+    ,   ("min-height", "400px")
+    ,   ("margin-top", "50px")
+    ,   ("background-color", "#424242")
+    ,   ("box-shadow", "0px 2px 5px #000000")
+    ]
 main = view


### PR DESCRIPTION
changed color scheme to dark based on: [dark theme at bottom](https://www.google.com/design/spec/style/color.html#color-themes)

created base container to wrap page content

created container for the actual markdown editor

![screen shot 2016-01-05 at 10 25 05 pm](https://cloud.githubusercontent.com/assets/7015773/12134226/35c17ba6-b3fb-11e5-83be-9a9d1c256afd.png)
